### PR TITLE
Allow Hashid to be typecast as int

### DIFF
--- a/hashid_field/hashid.py
+++ b/hashid_field/hashid.py
@@ -42,6 +42,9 @@ class Hashid(object):
     def __str__(self):
         return self.hashid
 
+    def __int__(self):
+        return self.id
+
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self.id == other.id and self.hashid == other.hashid


### PR DESCRIPTION
Django's ORM typecasts IntegerFields in multiple places. This allows that to work without raising a TypeError.