### PR TITLE
Add pickling + int/long equality

### DIFF
--- a/hashid_field/hashid.py
+++ b/hashid_field/hashid.py
@@ -7,7 +7,11 @@ from hashids import Hashids, _is_uint
 @total_ordering
 class Hashid(object):
     def __init__(self, id, salt='', min_length=0, alphabet=Hashids.ALPHABET):
-        self._hashids = Hashids(salt=salt, min_length=min_length, alphabet=alphabet)
+        self._salt = salt
+        self._min_length = min_length
+        self._alphabet = alphabet
+
+        self._hashids = Hashids(salt=self._salt, min_length=self._min_length, alphabet=self._alphabet)
 
         # First see if we were given an already-encoded and valid Hashids string
         value = self.decode(id)
@@ -58,11 +62,16 @@ class Hashid(object):
     def __int__(self):
         return self._id
 
+    def __long__(self):
+        return long(self._id)
+
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self._id == other._id and self._hashid == other._hashid
         if isinstance(other, six.string_types):
             return self._hashid == other
+        if isinstance(other, int) or isinstance(other, long):
+            return self._id == other
         return NotImplemented
 
     def __lt__(self, other):
@@ -77,3 +86,6 @@ class Hashid(object):
 
     def __hash__(self):
         return hash(self._hashid)
+
+    def __reduce__(self):
+        return (self.__class__, (self._id, self._salt, self._min_length, self._alphabet))

--- a/tests/test_hashid.py
+++ b/tests/test_hashid.py
@@ -1,3 +1,5 @@
+import pickle
+
 from django.test import TestCase
 from django.utils.encoding import force_text
 
@@ -56,6 +58,10 @@ class HashidTests(TestCase):
         a = Hashid(1)
         self.assertEqual(int(a), 1)
 
+    def test_typecast_to_long(self):
+        a = Hashid(1)
+        self.assertEqual(long(a), 1)
+
     def test_typecast_to_str(self):
         a = Hashid(1)
         self.assertEqual(str(a), a.hashid)
@@ -63,6 +69,14 @@ class HashidTests(TestCase):
     def test_str_compare(self):
         a = Hashid(1)
         self.assertTrue(str(a) == a)
+
+    def test_int_compare(self):
+        a = Hashid(1)
+        self.assertTrue(int(a) == a)
+
+    def test_long_compare(self):
+        a = Hashid(1)
+        self.assertTrue(long(a) == a)
 
     def test_hashid_equality(self):
         a = Hashid(123)
@@ -73,3 +87,8 @@ class HashidTests(TestCase):
         self.assertTrue(hash(a) == hash(str(b)))
         self.assertFalse(a == c)
         self.assertFalse(hash(a) == hash(c))
+
+    def test_pickle(self):
+        a = Hashid(123)
+        pickled = pickle.loads(pickle.dumps(a))
+        self.assertTrue(a == pickled)


### PR DESCRIPTION
- Adds the ability to pickle and unpickle an instance of a HashId
- Adds equality for `int` type: `int(a) == a`
- Adds equality for `long` type: `long(a) == a`
- Adds typecase to `long`