### PR TITLE
Bump to support Django 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
     ],
 
     # What does your project relate to?

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['Django>1.8,<1.12', 'hashids>=1.2.0'],
+    install_requires=['Django>1.8,<=2.0', 'hashids>=1.2.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/test_hashids_field.py
+++ b/tests/test_hashids_field.py
@@ -112,7 +112,7 @@ class HashidsTests(TestCase):
         c = Artist.objects.create(name="Artist C")
         queryset = Artist.objects.all()[:2]
         self.assertEqual(len(queryset), 2)
-        self.assertEqual(len(Artist.objects.filter(id__in=queryset)), 2)
+        self.assertEqual(len(Artist.objects.filter(id__in=queryset.values('id'))), 2)
 
     def test_get_object_or_404(self):
         a = Artist.objects.create(name="Artist A")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,35}-django{18,19,110,111}-{rest,norest}
+envlist = py{27,35}-django{18,19,110,111,20}-{rest,norest}
 
 [testenv]
 commands = python runtests.py
@@ -14,4 +14,5 @@ deps =
     django19: Django~=1.9.13
     django110: Django~=1.10.8
     django111: Django~=1.11.5
+    django20: Django~=2.0
     rest: djangorestframework==3.6.4


### PR DESCRIPTION
A couple of small changes to support Django 2.0. 

A few notes regarding testing: 
* The `test_subquery_lookup` function had to be modified to specify values in the subquery queryset; I'm not sure if this is a new behavior in Django 2.0 or not, but it was the only version that complained about it. All other versions tested fine via Tox. I hate modifying tests as part of a version bump, but it seemed necessary here.
* Tox complains when trying to install Django 2.0 on Python 2.7 -- Django 2.0 is the first version to release with no support for Python 2.x, so this isn't surprising. I'm not very familiar with Tox, so I wasn't sure how to modify tox.ini to tell it not to test Python 2.x / Django 2.0 in its test matrix. 

Please let me know if you need any further adjustments -- this is working great in my Django 2.0 project. Thank you for open sourcing this library :heart: