### PR TITLE
ModuleNotFoundError when installing package from github

### DIFF
--- a/hashid_field/__init__.py
+++ b/hashid_field/__init__.py
@@ -1,4 +1,2 @@
 from .field import HashidField, HashidAutoField
 from .hashid import Hashid
-
-__version__ = "2.1.2"

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,7 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 
-from django.conf import settings
-settings.configure()
-from hashid_field import __version__
+__version__ = "2.1.2"
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Importing `django` in `setup.py` to grab the version string blows up when installing this package from github and `django` isn't installed yet.

## Steps to reproduce

```
git clone https://github.com/didoarellano/fluffy-barnacle.git`
cd fluffy-barnacle
mkvirtualenv -p /usr/bin/python3.6 fluffy-barnacle
pip install -r requirements.txt
```

### Result:
![2018-09-21-17 31 21](https://user-images.githubusercontent.com/158018/45875051-257faa80-bdc9-11e8-8261-42a7990d4528.png)

## The fix
It's likely not the right way to do it but I moved the version string from `hashid_field/__init__.py` to `setup.py` so that `django` is no longer needed just to get the version. If there's a correct way of fixing this just point me in the right direction.

Installing from the "fixed" branch succeeds:
`pip install -r fixed_requirements.txt`