### PR TITLE
Fix RemovedInDjango30Warning on Django 2.0+

### DIFF
--- a/hashid_field/field.py
+++ b/hashid_field/field.py
@@ -1,5 +1,6 @@
 import warnings
 
+import django
 from django import forms
 from django.core import exceptions, checks
 from django.db import models
@@ -73,10 +74,16 @@ class HashidFieldMixin(object):
     def encode_id(self, id):
         return Hashid(id, salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
 
-    def from_db_value(self, value, expression, connection, context):
-        if value is None:
-            return value
-        return self.encode_id(value)
+    if django.VERSION < (2, 0):
+        def from_db_value(self, value, expression, connection, context):
+            if value is None:
+                return value
+            return self.encode_id(value)
+    else:
+        def from_db_value(self, value, expression, connection):
+            if value is None:
+                return value
+            return self.encode_id(value)
 
     def get_lookup(self, lookup_name):
         if lookup_name in self.exact_lookups:

--- a/runtests.py
+++ b/runtests.py
@@ -10,6 +10,7 @@ from django.test.utils import get_runner
 
 # Make deprecation warnings errors to ensure no usage of deprecated features.
 warnings.simplefilter("error", DeprecationWarning)
+warnings.simplefilter("error", PendingDeprecationWarning)
 # Make runtime warning errors to ensure no usage of error prone patterns.
 warnings.simplefilter("error", RuntimeWarning)
 # Ignore known warnings in test dependencies.


### PR DESCRIPTION
Fixes #27.

Also turning `PendingDeprecationWarning` into an error so this gets caught sooner in future.