### PR TITLE
Add django 3, remove python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 cache: pip
 dist: xenial
 python:
-  - 2.7
   - 3.6
+  - 3.7
+  - 3.8
 env:
   - DJANGO_VERSION=1.11.20
   - DJANGO_VERSION=2.1.8
@@ -11,16 +12,6 @@ env:
   - DJANGO_VERSION=1.11.20 DRF_VERSION=3.9.2
   - DJANGO_VERSION=2.1.8 DRF_VERSION=3.9.2
   - DJANGO_VERSION=2.2 DRF_VERSION=3.9.2
-matrix:
-  exclude:
-    - python: 2.7
-      env: DJANGO_VERSION=2.1.8
-    - python: 2.7
-      env: DJANGO_VERSION=2.1.8 DRF_VERSION=3.9.2
-    - python: 2.7
-      env: DJANGO_VERSION=2.2
-    - python: 2.7
-      env: DJANGO_VERSION=2.2 DRF_VERSION=3.9.2
 install:
   - pip install -r .travis/requirements.txt
   - pip install --upgrade "Django==${DJANGO_VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0] - 2019-12-XX
+### Changes
+- Dropped Python 2.7 support. 
+- Added Python 3.8 support. 
+- Added official support for Django 3.0
+- Added official support for Django Rest Framework 3.10.
+
 ## [2.1.6] - 2019-04-02
 ### Changes
 - Added official support for Django 2.2 LTS.

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ Requirements
 
 This module is tested and known to work with:
 
-* Python 2.7, 3.6, 3.7
-* Django 1.11, 2.1, 2.2
+* Python 3.6, 3.7, 3.8
+* Django 1.11, 2.1, 2.2, 3.0
 * Hashids 1.2
 * Django REST Framework 3.9
 
@@ -73,6 +73,7 @@ Migrate your database
 
 Upgrading
 ------------
+**Version 2.2 follows Django 3.0 and drops support for Python 2.7.**
 
 **Potentially breaking changes in 2.0.0** depending on your usage and configuration, specifically if you rely on
 integer lookups (now off by default) or exceptions for invalid lookup values.

--- a/hashid_field/field.py
+++ b/hashid_field/field.py
@@ -4,7 +4,7 @@ import django
 from django import forms
 from django.core import exceptions, checks
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.admin import widgets as admin_widgets
 from hashids import Hashids
 

--- a/hashid_field/field.py
+++ b/hashid_field/field.py
@@ -33,16 +33,16 @@ class HashidFieldMixin(object):
             allow_int_lookup = kwargs['allow_int']
             del kwargs['allow_int']
         self.allow_int_lookup = allow_int_lookup
-        super(HashidFieldMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def deconstruct(self):
-        name, path, args, kwargs = super(HashidFieldMixin, self).deconstruct()
+        name, path, args, kwargs = super().deconstruct()
         kwargs['min_length'] = self.min_length
         kwargs['alphabet'] = self.alphabet
         return name, path, args, kwargs
 
     def check(self, **kwargs):
-        errors = super(HashidFieldMixin, self).check(**kwargs)
+        errors = super().check(**kwargs)
         errors.extend(self._check_alphabet_min_length())
         errors.extend(self._check_salt_is_set())
         return errors
@@ -91,7 +91,7 @@ class HashidFieldMixin(object):
         if lookup_name in self.iterable_lookups:
             return HashidIterableLookup
         if lookup_name in self.passthrough_lookups:
-            return super(HashidFieldMixin, self).get_lookup(lookup_name)
+            return super().get_lookup(lookup_name)
         return None  # Otherwise, we don't allow lookups of this type
 
     def to_python(self, value):
@@ -121,7 +121,7 @@ class HashidFieldMixin(object):
         return hashid.id
 
     def contribute_to_class(self, cls, name, **kwargs):
-        super(HashidFieldMixin, self).contribute_to_class(cls, name, **kwargs)
+        super().contribute_to_class(cls, name, **kwargs)
         # setattr(cls, "_" + self.attname, getattr(cls, self.attname))
         setattr(cls, self.attname, HashidDescriptor(self.attname, salt=self.salt, min_length=self.min_length, alphabet=self.alphabet))
 
@@ -134,7 +134,7 @@ class HashidField(HashidFieldMixin, models.IntegerField):
         defaults.update(kwargs)
         if defaults.get('widget') == admin_widgets.AdminIntegerFieldWidget:
             defaults['widget'] = admin_widgets.AdminTextInputWidget
-        return super(HashidField, self).formfield(**defaults)
+        return super().formfield(**defaults)
 
 
 class HashidAutoField(HashidFieldMixin, models.AutoField):

--- a/hashid_field/hashid.py
+++ b/hashid_field/hashid.py
@@ -1,7 +1,6 @@
 import sys
 from functools import total_ordering
 
-from django.utils import six
 from hashids import Hashids, _is_uint
 
 
@@ -72,9 +71,9 @@ class Hashid(object):
     def __eq__(self, other):
         if isinstance(other, self.__class__):
             return self._id == other._id and self._hashid == other._hashid
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             return self._hashid == other
-        if isinstance(other, six.integer_types):
+        if isinstance(other, int):
             return self._id == other
         return NotImplemented
 

--- a/hashid_field/lookups.py
+++ b/hashid_field/lookups.py
@@ -120,7 +120,7 @@ class HashidIterableLookup(HashidLookup):
 
     def get_prep_lookup(self):
         if django.VERSION[0] <= 1 and django.VERSION[1] <= 8:
-            return super(HashidIterableLookup, self).get_prep_lookup()
+            return super().get_prep_lookup()
         prepared_values = []
         if hasattr(self.rhs, '_prepare'):
             # A subquery is like an iterable but its items shouldn't be
@@ -157,7 +157,7 @@ class HashidIterableLookup(HashidLookup):
             placeholder = '(' + ', '.join(sqls) + ')'
             return (placeholder, sqls_params)
         else:
-            return super(HashidIterableLookup, self).process_rhs(compiler, connection)
+            return super().process_rhs(compiler, connection)
 
     def resolve_expression_parameter(self, compiler, connection, sql, param):
         params = [param]
@@ -168,7 +168,7 @@ class HashidIterableLookup(HashidLookup):
         return sql, params
 
     def batch_process_rhs(self, compiler, connection, rhs=None):
-        pre_processed = super(HashidIterableLookup, self).batch_process_rhs(compiler, connection, rhs)
+        pre_processed = super().batch_process_rhs(compiler, connection, rhs)
         # The params list may contain expressions which compile to a
         # sql/param pair. Zip them to get sql and param pairs that refer to the
         # same argument and attempt to replace them with the result of

--- a/hashid_field/lookups.py
+++ b/hashid_field/lookups.py
@@ -122,10 +122,10 @@ class HashidIterableLookup(HashidLookup):
         if django.VERSION[0] <= 1 and django.VERSION[1] <= 8:
             return super().get_prep_lookup()
         prepared_values = []
-        if hasattr(self.rhs, '_prepare'):
+        if hasattr(self.rhs, 'subquery') and self.rhs.subquery:
             # A subquery is like an iterable but its items shouldn't be
             # prepared independently.
-            return self.rhs._prepare(self.lhs.output_field)
+            return self.rhs
         for rhs_value in self.rhs:
             if hasattr(rhs_value, 'resolve_expression'):
                 # An expression will be handled by the database but can coexist

--- a/hashid_field/rest.py
+++ b/hashid_field/rest.py
@@ -10,7 +10,7 @@ from hashid_field.hashid import Hashid
 
 class UnconfiguredHashidSerialField(fields.Field):
     def bind(self, field_name, parent):
-        super(UnconfiguredHashidSerialField, self).bind(field_name, parent)
+        super().bind(field_name, parent)
         raise exceptions.ImproperlyConfigured(
             "The field '{field_name}' on {parent} must be explicitly declared when used with a ModelSerializer".format(
                 field_name=field_name, parent=parent.__class__.__name__))
@@ -39,11 +39,11 @@ class HashidSerializerMixin(object):
             self.hashid_salt, self.hashid_min_length, self.hashid_alphabet = \
                 source_field.salt, source_field.min_length, source_field.alphabet
 
-        super(HashidSerializerMixin, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def to_internal_value(self, data):
         try:
-            value = super(HashidSerializerMixin, self).to_internal_value(data)
+            value = super().to_internal_value(data)
             return Hashid(value, salt=self.hashid_salt, min_length=self.hashid_min_length, alphabet=self.hashid_alphabet)
         except ValueError:
             raise serializers.ValidationError("Invalid int or Hashid string")

--- a/hashid_field/rest.py
+++ b/hashid_field/rest.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from django.core import exceptions
-from django.utils import six
+
 from hashids import Hashids
 from rest_framework import fields, serializers
 
@@ -27,7 +27,7 @@ class HashidSerializerMixin(object):
         source_field = kwargs.pop('source_field', None)
         if source_field:
             from hashid_field import HashidField, HashidAutoField
-            if isinstance(source_field, six.string_types):
+            if isinstance(source_field, str):
                 try:
                     app_label, model_name, field_name = source_field.split(".")
                 except ValueError:

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function, unicode_literals
 import os
 import sys
 import warnings

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
-universal=1
+universal=0

--- a/setup.py
+++ b/setup.py
@@ -87,17 +87,17 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
 
         # Django
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
     ],
 
     # What does your project relate to?

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from django.utils import six
 
 from hashid_field.field import Hashid
 from hashid_field.descriptor import HashidDescriptor
@@ -80,7 +79,7 @@ class DescriptorTests(TestCase):
     def test_reset_after_invalid_set(self):
         t = TestClass()
         t.hashid = "asdf"  # First set it to something invalid, so the descriptor will just set it to this string
-        self.assertIsInstance(t.hashid, six.string_types)
+        self.assertIsInstance(t.hashid, str)
         self.assertEqual(t.hashid, "asdf")
         t.hashid = 123  # Now set it to a valid value for a Hashid, so it should create a new Hashid()
         self.assertIsInstance(t.hashid, Hashid)

--- a/tests/test_hashid.py
+++ b/tests/test_hashid.py
@@ -3,7 +3,7 @@ from unittest import skipIf
 
 import sys
 from django.test import TestCase
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from hashid_field import Hashid
 
@@ -51,7 +51,7 @@ class HashidTests(TestCase):
 
     def test_force_text(self):
         h = Hashid(2923)
-        t = force_text(h)
+        t = force_str(h)
         self.assertEqual(t, h.hashid)
 
     def test_sorting(self):

--- a/tests/test_hashids_field.py
+++ b/tests/test_hashids_field.py
@@ -1,7 +1,7 @@
 from django.core.management import call_command
 from django.shortcuts import get_object_or_404
 from django.test import TestCase, override_settings
-from django.utils.six import StringIO
+from io import StringIO
 
 from hashid_field import Hashid
 from tests.forms import RecordForm, AlternateRecordForm

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -2,7 +2,6 @@ from unittest import skipUnless
 
 from django.core import exceptions
 from django.test import TestCase
-from django.utils import six
 
 from tests.models import Artist
 
@@ -39,7 +38,7 @@ class TestRestFramework(TestCase):
         orig_id = artist.id
         s = ArtistSerializer(artist)
         self.assertEqual(Artist._meta.get_field('id').salt, s.fields['id'].hashid_salt)
-        self.assertTrue(isinstance(s.data['id'], six.string_types))
+        self.assertTrue(isinstance(s.data['id'], str))
         self.assertEqual(artist.id.hashid, s.data['id'])
         s2 = ArtistSerializer(artist, data={'id': 128, 'name': "Test Artist Changed"})
         self.assertTrue(s2.is_valid())

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,36}-django111-{rest,norest},
-          py36-django{21,22}-{rest,norest},
-          py37-django{21,22}-{rest,norest}
+envlist = py36-django111-{rest,norest},
+          py36-django{21,22,30}-{rest,norest},
+          py37-django{21,22,30}-{rest,norest}:
+          py38-django{21,22,30}-{rest,norest}:
 
 [testenv]
 commands = python runtests.py
@@ -15,4 +16,5 @@ deps =
     django111: Django~=1.11.20
     django21: Django~=2.1.8
     django22: Django~=2.2
+    django30: Django~=3.0
     rest: djangorestframework==3.9.2


### PR DESCRIPTION
#35, #36, 
Drop Python 2.7 support, and change to more idiomatic Python 3.
Removes all references to `six` compatibility dependency, which also has the effect of adding support for Django 3.0.
Also tested with Python 3.8, no issues noticed, so I added it to the test matrix. Supported Python versions are now from 3.6 to 3.8.
Note I didn't add DRF 3.10, it shouldn't have issues either, but I didn't check.

Django 3 adds some deprecations warnings related to Django 4, 
`django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy()` and `force_text() is deprecated in favor of force_str()`
I updated as such.

Locally tested with Python 3.8, Django 2.2, 2.2.8, and 3.0

There was one outstanding error detected, only with Django 3.
`test_subquery_lookup` fails, with `TypeError: 'Query' object is not iterable`. 
It refers to the loop in lookups.py, l129 `for rhs_value in self.rhs:`. The previous check couldn't pickup the bound method `_prepare`, as it has been removed in Django 3. It originally only returned self anyway.
