### PR TITLE
Cache the hashids object.

### DIFF
--- a/hashid_field/descriptor.py
+++ b/hashid_field/descriptor.py
@@ -9,6 +9,7 @@ class HashidDescriptor(object):
         self.salt = salt
         self.min_length = min_length
         self.alphabet = alphabet
+        self._hashids = Hashids(salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
 
     def __get__(self, instance, owner=None):
         if instance is not None and self.name in instance.__dict__:
@@ -21,6 +22,6 @@ class HashidDescriptor(object):
             instance.__dict__[self.name] = value
         else:
             try:
-                instance.__dict__[self.name] = Hashid(value, salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
+                instance.__dict__[self.name] = Hashid(value, hashids=self._hashids)
             except ValueError:
                 instance.__dict__[self.name] = value

--- a/hashid_field/field.py
+++ b/hashid_field/field.py
@@ -35,6 +35,7 @@ class HashidFieldMixin(object):
         self.salt = salt
         self.min_length = min_length
         self.alphabet = alphabet
+        self._hashids = Hashids(salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
         if 'allow_int' in kwargs:
             warnings.warn("The 'allow_int' parameter was renamed to 'allow_int_lookup'.", DeprecationWarning, stacklevel=2)
             allow_int_lookup = kwargs['allow_int']
@@ -79,7 +80,7 @@ class HashidFieldMixin(object):
         return []
 
     def encode_id(self, id):
-        return Hashid(id, salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
+        return Hashid(id, hashids=self._hashids)
 
     if django.VERSION < (2, 0):
         def from_db_value(self, value, expression, connection, context):

--- a/hashid_field/hashid.py
+++ b/hashid_field/hashid.py
@@ -6,12 +6,14 @@ from hashids import Hashids, _is_uint
 
 @total_ordering
 class Hashid(object):
-    def __init__(self, id, salt='', min_length=0, alphabet=Hashids.ALPHABET):
+    def __init__(self, id, salt='', min_length=0, alphabet=Hashids.ALPHABET, hashids=None):
+        if hashids is not None and salt:
+            raise ValueError("Cannot use hashids and salt at the same time")
         self._salt = salt
         self._min_length = min_length
         self._alphabet = alphabet
 
-        self._hashids = Hashids(salt=self._salt, min_length=self._min_length, alphabet=self._alphabet)
+        self._hashids = hashids or Hashids(salt=self._salt, min_length=self._min_length, alphabet=self._alphabet)
 
         # First see if we were given an already-encoded and valid Hashids string
         value = self.decode(id)

--- a/hashid_field/rest.py
+++ b/hashid_field/rest.py
@@ -38,13 +38,13 @@ class HashidSerializerMixin(object):
                 raise TypeError(self.usage_text)
             self.hashid_salt, self.hashid_min_length, self.hashid_alphabet = \
                 source_field.salt, source_field.min_length, source_field.alphabet
-
+        self._hashids = Hashids(salt=self.hashid_salt, min_length=self.hashid_min_length, alphabet=self.hashid_alphabet)
         super().__init__(**kwargs)
 
     def to_internal_value(self, data):
         try:
             value = super().to_internal_value(data)
-            return Hashid(value, salt=self.hashid_salt, min_length=self.hashid_min_length, alphabet=self.hashid_alphabet)
+            return Hashid(value, self._hashids)
         except ValueError:
             raise serializers.ValidationError("Invalid int or Hashid string")
 


### PR DESCRIPTION
Creating the Hashids and then encoding the id every time appears to take ~3x more time than having the Hashids object cached and ready to encode a new id.

A change like this does seem to improve performance quite a bit for scenarios where a lot of objects are being serialized. 

---

I've made the changes backwards compatible (I think), but let me know if something else would be preferred instead. 

