### PR TITLE
implement optional prefix to the field

### DIFF
--- a/hashid_field/descriptor.py
+++ b/hashid_field/descriptor.py
@@ -4,11 +4,12 @@ from .hashid import Hashid
 
 
 class HashidDescriptor(object):
-    def __init__(self, name, salt='', min_length=0, alphabet=Hashids.ALPHABET, hashids=None):
+    def __init__(self, name, salt='', min_length=0, alphabet=Hashids.ALPHABET, hashids=None, prefix=None):
         self.name = name
         self.salt = salt
         self.min_length = min_length
         self.alphabet = alphabet
+        self.prefix = prefix
         if hashids is None:
             self._hashids = Hashids(salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
         else:
@@ -25,6 +26,6 @@ class HashidDescriptor(object):
             instance.__dict__[self.name] = value
         else:
             try:
-                instance.__dict__[self.name] = Hashid(value, hashids=self._hashids)
+                instance.__dict__[self.name] = Hashid(value, hashids=self._hashids, prefix=self.prefix)
             except ValueError:
                 instance.__dict__[self.name] = value

--- a/hashid_field/field.py
+++ b/hashid_field/field.py
@@ -35,7 +35,7 @@ class HashidFieldMixin(object):
     }
 
     def __init__(self, salt=settings.HASHID_FIELD_SALT, min_length=7, alphabet=Hashids.ALPHABET,
-                 allow_int_lookup=settings.HASHID_FIELD_ALLOW_INT_LOOKUP, *args, **kwargs):
+                 allow_int_lookup=settings.HASHID_FIELD_ALLOW_INT_LOOKUP, prefix=None, *args, **kwargs):
         self.salt = salt
         self.min_length = min_length
         self.alphabet = alphabet
@@ -47,12 +47,14 @@ class HashidFieldMixin(object):
             allow_int_lookup = kwargs['allow_int']
             del kwargs['allow_int']
         self.allow_int_lookup = allow_int_lookup
+        self.prefix = prefix
         super().__init__(*args, **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
         kwargs['min_length'] = self.min_length
         kwargs['alphabet'] = self.alphabet
+        kwargs['prefix'] = self.prefix
         return name, path, args, kwargs
 
     def check(self, **kwargs):
@@ -86,7 +88,7 @@ class HashidFieldMixin(object):
         return []
 
     def encode_id(self, id):
-        return Hashid(id, hashids=self._hashids)
+        return Hashid(id, hashids=self._hashids, prefix=self.prefix)
 
     if django.VERSION < (2, 0):
         def from_db_value(self, value, expression, connection, context):
@@ -139,7 +141,7 @@ class HashidFieldMixin(object):
     def contribute_to_class(self, cls, name, **kwargs):
         super().contribute_to_class(cls, name, **kwargs)
         # setattr(cls, "_" + self.attname, getattr(cls, self.attname))
-        setattr(cls, self.attname, HashidDescriptor(self.attname, hashids=self._hashids))
+        setattr(cls, self.attname, HashidDescriptor(self.attname, hashids=self._hashids, prefix=self.prefix))
 
 
 class HashidField(HashidFieldMixin, models.IntegerField):

--- a/hashid_field/rest.py
+++ b/hashid_field/rest.py
@@ -23,6 +23,7 @@ class HashidSerializerMixin(object):
         self.hashid_salt = kwargs.pop('salt', settings.HASHID_FIELD_SALT)
         self.hashid_min_length = kwargs.pop('min_length', 7)
         self.hashid_alphabet = kwargs.pop('alphabet', Hashids.ALPHABET)
+        self.prefix = None
 
         source_field = kwargs.pop('source_field', None)
         if source_field:
@@ -36,15 +37,15 @@ class HashidSerializerMixin(object):
                 source_field = model._meta.get_field(field_name)
             elif not isinstance(source_field, (HashidField, HashidAutoField)):
                 raise TypeError(self.usage_text)
-            self.hashid_salt, self.hashid_min_length, self.hashid_alphabet = \
-                source_field.salt, source_field.min_length, source_field.alphabet
+            self.hashid_salt, self.hashid_min_length, self.hashid_alphabet, self.prefix = \
+                source_field.salt, source_field.min_length, source_field.alphabet, source_field.prefix
         self._hashids = Hashids(salt=self.hashid_salt, min_length=self.hashid_min_length, alphabet=self.hashid_alphabet)
         super().__init__(**kwargs)
 
     def to_internal_value(self, data):
         try:
             value = super().to_internal_value(data)
-            return Hashid(value, hashids=self._hashids)
+            return Hashid(value, hashids=self._hashids, prefix=self.prefix)
         except ValueError:
             raise serializers.ValidationError("Invalid int or Hashid string")
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -20,3 +20,6 @@ class Record(models.Model):
 
     def __str__(self):
         return "{} ({})".format(self.name, self.reference_id)
+
+class Track(models.Model):
+    id = HashidAutoField(primary_key=True, allow_int_lookup=True, min_length=10, prefix=1, salt="abcd", alphabet="abcdefghijklmnop")

--- a/tests/test_hashids_field.py
+++ b/tests/test_hashids_field.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 from hashid_field import Hashid, HashidField
 from tests.forms import RecordForm, AlternateRecordForm
-from tests.models import Record, Artist
+from tests.models import Record, Artist, Track
 
 
 class HashidsTests(TestCase):
@@ -316,3 +316,19 @@ class HashidsTests(TestCase):
             HashidField(alphabet="aaaaaaaaaaaaaaaaaaaaa")  # not unique
         with self.assertRaises(exceptions.ImproperlyConfigured):
             HashidField(alphabet="aabcdefghijklmno")  # not unique by one
+
+    def test_encode_with_prefix(self):
+        SALT = "abcd"
+        ALPHABET = "abcdefghijklmnop"
+
+        field_without_prefix = HashidField(min_length=5)
+        field_with_prefix = HashidField(min_length=5, prefix=1)
+
+        hashed_id_without_prefix = field_without_prefix.encode_id(1)
+        hashed_id_with_prefix = field_with_prefix.encode_id(1)
+
+        self.assertNotEqual(hashed_id_without_prefix, hashed_id_with_prefix)
+
+    def test_decode_with_prefix(self):
+        instance = Track.objects.create()
+        self.assertEqual(1, Track.objects.filter(id=1).count())

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -3,7 +3,8 @@ from unittest import skipUnless
 from django.core import exceptions
 from django.test import TestCase
 
-from tests.models import Artist
+from tests.models import Artist, Track
+import hashids
 
 try:
     from rest_framework import serializers
@@ -79,3 +80,21 @@ class TestRestFramework(TestCase):
         with self.assertRaises(exceptions.FieldDoesNotExist):
             id = HashidSerializerIntegerField(source_field="tests.Artist.baz")
 
+    def test_modelserializer_with_prefix(self):
+        class TrackSerializer(serializers.ModelSerializer):
+            id = HashidSerializerCharField(source_field="tests.Track.id")
+
+            class Meta:
+                model = Track
+                fields = ("id",)
+
+        salt = Track._meta.get_field("id").salt
+        alphabet = Track._meta.get_field("id").alphabet
+        min_length = Track._meta.get_field("id").min_length
+        reference = hashids.Hashids(salt=salt, min_length=min_length, alphabet=alphabet)
+
+        track = Track.objects.create()
+        self.assertEqual(reference.encode(1, 1), track.id)
+
+        serializer = TrackSerializer(track)
+        self.assertEqual(serializer.data["id"], reference.encode(1, 1))


### PR DESCRIPTION
I stumbled upon the issue #31 however instead of adding a custom salt I thought that it'd be nice to have a custom prefix. The reason would be that, if somebody would pass an invalid ID as an URL parameter, I'd be able to detect that even prior to hitting the database. As an additional benefit, if you'd have two models, encoding a primary key with a value `1` and on two separate models (with two prefixes) would yield two different hashes.

this change is backwards compatible - the prefix is optional.

not sure if I made the correct unit test scenarios :)

cheers