### PR TITLE
Adds support for optional string prefix to hashid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -251,8 +251,8 @@ Field Parameters
 Besides the standard field options, there are settings you can tweak that are specific to HashidField and
 AutoHashidField.
 
-**Please note** that changing any of the values for ``salt``, ``min_length`` or ``alphabet`` *will* affect the
-obfuscation of the integers that are stored in the database, and will change what are considered "valid" hashids.
+**Please note** that changing any of the values for ``salt``, ``min_length``, ``alphabet`` or ``prefix`` *will* affect
+the obfuscation of the integers that are stored in the database, and will change what are considered "valid" hashids.
 If you have links or URLs that include your HashidField values, then they will stop working after changing any of these
 values. It's highly advised that you don't change any of these settings once you publish any references to your field.
 
@@ -289,6 +289,23 @@ alphabet
         # Only use numbers and lower-case letters
         reference_id = HashidField(alphabet="0123456789abcdefghijklmnopqrstuvwxyz")
 
+prefix
+~~~~~~
+
+:Type:    String or callable object.
+:Default: ''
+:Example:
+    .. code-block:: python
+
+        # Using URLs for identifiers:
+        reference_id = HashidField(prefix="https://example.com/")
+
+        # Using a callable that inserts the field name:
+        def get_prefix(field_name, **kw):
+            return 'myids:{}:'.format(field_name)
+        reference_id = HashidField(prefix=get_prefix)
+
+
 allow_int_lookup
 ~~~~~~~~~~~~~~~~
 
@@ -309,13 +326,14 @@ converting integers and hashid strings back and forth. There shouldn't be any ne
 Methods
 ~~~~~~~
 
-\__init__(id, salt='', min_length=0, alphabet=Hashids.ALPHABET):
+\__init__(id, salt='', min_length=0, alphabet=Hashids.ALPHABET, prefix=''):
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :id: **REQUIRED** Integer you wish to *encode*
 :salt: Salt to use. **Default**: ''
 :min_length: Minimum length of encoded hashid string. **Default**: 0
 :alphabet: The characters to use in the encoded hashid string. **Default**: Hashids.ALPHABET
+:prefix: String prefix prepended to hashid strings. **Default**: ''
 
 Read-Only Properties
 ~~~~~~~~~~~~~~~~~~~~

--- a/hashid_field/descriptor.py
+++ b/hashid_field/descriptor.py
@@ -4,11 +4,12 @@ from .hashid import Hashid
 
 
 class HashidDescriptor(object):
-    def __init__(self, name, salt='', min_length=0, alphabet=Hashids.ALPHABET, hashids=None):
+    def __init__(self, name, salt='', min_length=0, alphabet=Hashids.ALPHABET, hashids=None, prefix=''):
         self.name = name
         self.salt = salt
         self.min_length = min_length
         self.alphabet = alphabet
+        self.prefix = prefix
         if hashids is None:
             self._hashids = Hashids(salt=self.salt, min_length=self.min_length, alphabet=self.alphabet)
         else:
@@ -25,6 +26,6 @@ class HashidDescriptor(object):
             instance.__dict__[self.name] = value
         else:
             try:
-                instance.__dict__[self.name] = Hashid(value, hashids=self._hashids)
+                instance.__dict__[self.name] = Hashid(value, hashids=self._hashids, prefix=self.prefix)
             except ValueError:
                 instance.__dict__[self.name] = value

--- a/hashid_field/field.py
+++ b/hashid_field/field.py
@@ -35,7 +35,7 @@ class HashidFieldMixin(object):
     }
 
     def __init__(self, salt=settings.HASHID_FIELD_SALT, min_length=7, alphabet=Hashids.ALPHABET,
-                 allow_int_lookup=settings.HASHID_FIELD_ALLOW_INT_LOOKUP, *args, **kwargs):
+                 allow_int_lookup=settings.HASHID_FIELD_ALLOW_INT_LOOKUP, prefix='', *args, **kwargs):
         self.salt = salt
         self.min_length = min_length
         self.alphabet = alphabet
@@ -47,12 +47,14 @@ class HashidFieldMixin(object):
             allow_int_lookup = kwargs['allow_int']
             del kwargs['allow_int']
         self.allow_int_lookup = allow_int_lookup
+        self.prefix = prefix
         super().__init__(*args, **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()
         kwargs['min_length'] = self.min_length
         kwargs['alphabet'] = self.alphabet
+        kwargs['prefix'] = self.prefix
         return name, path, args, kwargs
 
     def check(self, **kwargs):
@@ -86,7 +88,7 @@ class HashidFieldMixin(object):
         return []
 
     def encode_id(self, id):
-        return Hashid(id, hashids=self._hashids)
+        return Hashid(id, hashids=self._hashids, prefix=self.prefix)
 
     if django.VERSION < (2, 0):
         def from_db_value(self, value, expression, connection, context):
@@ -138,8 +140,10 @@ class HashidFieldMixin(object):
 
     def contribute_to_class(self, cls, name, **kwargs):
         super().contribute_to_class(cls, name, **kwargs)
+        if callable(self.prefix):
+            self.prefix = self.prefix(field_instance=self, model_class=cls, field_name=name, **kwargs)
         # setattr(cls, "_" + self.attname, getattr(cls, self.attname))
-        setattr(cls, self.attname, HashidDescriptor(self.attname, hashids=self._hashids))
+        setattr(cls, self.attname, HashidDescriptor(self.attname, hashids=self._hashids, prefix=self.prefix))
 
 
 class HashidField(HashidFieldMixin, models.IntegerField):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,4 @@
 from django.db import models
-from time import time
 
 from hashid_field import HashidAutoField, HashidField
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from time import time
 
 from hashid_field import HashidAutoField, HashidField
 
@@ -20,3 +21,14 @@ class Record(models.Model):
 
     def __str__(self):
         return "{} ({})".format(self.name, self.reference_id)
+
+
+class Track(models.Model):
+    id = HashidAutoField(primary_key=True, allow_int_lookup=True, min_length=10, prefix='albumtrack:', salt="abcd", alphabet="abcdefghijklmnop")
+
+
+class RecordLabel(models.Model):
+    def name_prefix(model_class, **kw):
+        return model_class._meta.verbose_name.replace(' ', '_') + '/'
+
+    id = HashidAutoField(primary_key=True, allow_int_lookup=True, prefix=name_prefix)

--- a/tests/test_hashids_field.py
+++ b/tests/test_hashids_field.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 from hashid_field import Hashid, HashidField
 from tests.forms import RecordForm, AlternateRecordForm
-from tests.models import Record, Artist
+from tests.models import Record, Artist, Track, RecordLabel
 
 
 class HashidsTests(TestCase):
@@ -316,3 +316,25 @@ class HashidsTests(TestCase):
             HashidField(alphabet="aaaaaaaaaaaaaaaaaaaaa")  # not unique
         with self.assertRaises(exceptions.ImproperlyConfigured):
             HashidField(alphabet="aabcdefghijklmno")  # not unique by one
+
+    def test_encode_with_prefix(self):
+        SALT = "abcd"
+        ALPHABET = "abcdefghijklmnop"
+
+        field_without_prefix = HashidField(min_length=5)
+        field_with_prefix = HashidField(min_length=5, prefix=1)
+
+        hashed_id_without_prefix = field_without_prefix.encode_id(1)
+        hashed_id_with_prefix = field_with_prefix.encode_id(1)
+
+        self.assertNotEqual(hashed_id_without_prefix, hashed_id_with_prefix)
+
+
+    def test_decode_with_prefix(self):
+        instance = Track.objects.create()
+        self.assertEqual(1, Track.objects.filter(id=1).count())
+
+
+    def test_dynamic_prefix(self):
+        instance = RecordLabel.objects.create()
+        self.assertEqual(instance.id, 'record_label/Yd3axGx')


### PR DESCRIPTION
I'm opening this PR for discussion.

This work is partially inspired by/based on #49 but in implementing it I realized that my use case is somewhat different from @toudi because it looks like he's hoping for an integer "prefix" that gets encoded within the hashid, whereas I'd like to see string prefixes prepended to the hashid after encoding.

What I've got here passes tests and solves my problem, but I'm less certain whether this feature belongs in this library.

See also: discussion on #21 