### PR TITLE
Include internal hashid state into the picking state

### DIFF
--- a/hashid_field/hashid.py
+++ b/hashid_field/hashid.py
@@ -149,3 +149,9 @@ class Hashid(object):
 
     def __reduce__(self):
         return (self.__class__, (self._id, self._salt, self._min_length, self._alphabet, self._prefix, None))
+
+    def __getstate__(self):
+        return (self._id, self._salt, self._min_length, self._alphabet, self._prefix, self._hashid)
+
+    def __setstate__(self, state):
+        self._id, self._salt, self._min_length, self._alphabet, self._prefix, self._hashid = state

--- a/hashid_field/hashid.py
+++ b/hashid_field/hashid.py
@@ -147,9 +147,6 @@ class Hashid(object):
     def __hash__(self):
         return hash(str(self))
 
-    def __reduce__(self):
-        return (self.__class__, (self._id, self._salt, self._min_length, self._alphabet, self._prefix, None))
-
     def __getstate__(self):
         return (self._id, self._salt, self._min_length, self._alphabet, self._prefix, self._hashid)
 


### PR DESCRIPTION
I hit the same issue as in #55 with [`django-cacheops`](https://github.com/Suor/django-cacheops) and `django-hashid-field`.

Unfortunately for me, that `enable_hashid_object=False` "workaround" can't be applied in my case, but I've found that if you include `self._hashids` attribute into the pickled state, hashid objects can be successfully deserialized from the cache provided by `django-cacheops`.
As a side thought: the actual fix might be that some other attribute is now excluded from the pickled representation, but I'm not exactly sure what else can affect this behavior in here.

Please note that this is a breaking change as it changes pickling behavior.
