### PR TITLE
Add logic to in lookup to select only the PK on subqueries

### DIFF
--- a/tests/test_hashids_field.py
+++ b/tests/test_hashids_field.py
@@ -205,6 +205,14 @@ class HashidsTests(TestCase):
         self.assertEqual(len(queryset), 2)
         self.assertEqual(len(Artist.objects.filter(id__in=queryset.values('id'))), 2)
 
+    def test_subquery_lookup_without_specified_values(self):
+        a = Artist.objects.create(name="Artist A")
+        b = Artist.objects.create(name="Artist B")
+        c = Artist.objects.create(name="Artist C")
+        queryset = Artist.objects.all()[:2]
+        self.assertEqual(len(queryset), 2)
+        self.assertEqual(len(Artist.objects.filter(id__in=queryset)), 2)
+
     def test_passthrough_lookups(self):
         # Test null lookups
         self.assertTrue(Record.objects.filter(alternate_id__isnull=True).exists())


### PR DESCRIPTION
The default In lookup prep performs logic to make it such that developers do not have to explicitly call `values('id')` or `values('pk')` when writing subqueries on the ID value. This backports the same logic implemented today in the core `In` lookup class to make it work the same way for hashid fields.

The clear_ordering function is noted in Django 3 to have side effect bugs regarding certain array subqueries in Postgresql, and the clearing of the ordering was not added to the In class until Django 4 anyway, so the order clearing is only included in Django > 4.0 by default to keep behaviors consistent.

See [django/django](https://github.com/django/django/blob/d87a7b9f4b/django/db/models/lookups.py#L419-L425) source for core implementation