### PR TITLE
App config doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,7 @@ from taking affect. If you are attempting to use the global setting, you should 
 `project/app_name/apps.py` to ensure they don't interfere.
 
 .. code-block:: python
+
     from django.apps import AppConfig
 
 

--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,19 @@ Care must be given, as this will alter ALL models in your project. Usually you w
 Also, since this changes the auto-generated field, only global settings will be used for that field. If you desire
 specific settings for different models, then using this setting is not advised.
 
+Django may configure the per-app `default_auto_field` when a new app is created. This will prevent the global setting
+from taking affect. If you are attempting to use the global setting, you should check your app configs in
+`project/app_name/apps.py` to ensure they don't interfere.
+
+.. code-block:: python
+    from django.apps import AppConfig
+
+
+    class ScheduleConfig(AppConfig):
+        default_auto_field = 'django.db.models.BigAutoField'
+        name = 'schedule'
+
+
 Global Settings
 ---------------
 


### PR DESCRIPTION
Hi, turns out my brand-new apps had the auto field set automatically, overriding the default from `settings.py`. This took me a few minutes to find. I added docs that might help others avoid this pitfall.

Let me know if you want any additional changes.